### PR TITLE
Added TagManager preset and check

### DIFF
--- a/Editor/WorldValidator.cs
+++ b/Editor/WorldValidator.cs
@@ -122,11 +122,11 @@ namespace VeryRealHelp.HelpClubCommon.Editor
                 () => GraphicsSettings.renderPipelineAsset == null
             ),
             new CheckCollection.Check(
-                $"Quality Settings", "Should use Quality Settings from Preset",
+                $"Quality Settings", "Auto applying Quality Settings from Preset",
                 () => {
                     var cachedActiveObject = Selection.activeObject;
                     Preset qualitySettings = (Preset)AssetDatabase.LoadAssetAtPath("Packages/com.veryrealhelp.helpclubcommon/Presets/QualitySettings.preset", typeof(Preset));
-                    Selection.activeObject = Unsupported.GetSerializedAssetInterfaceSingleton("QualitySettings"); //Workaround: no motheds exposed in 2019 LTS to directly access editors quality settings (Project/Quality)
+                    Selection.activeObject = Unsupported.GetSerializedAssetInterfaceSingleton("QualitySettings"); //Workaround: no metheds exposed in 2019 LTS to directly access editors quality settings (Project/Quality)
                     bool presetEquals = qualitySettings.DataEquals(Selection.activeObject);
                     Selection.activeObject = cachedActiveObject;
                     return presetEquals;
@@ -138,6 +138,26 @@ namespace VeryRealHelp.HelpClubCommon.Editor
                     Selection.activeObject = SettingsService.OpenProjectSettings("Project/Quality");
                     Selection.activeObject = Unsupported.GetSerializedAssetInterfaceSingleton("QualitySettings");
                     qualitySettings.ApplyTo(Selection.activeObject);
+                    Selection.activeObject = cachedActiveObject;
+                }
+            ),
+            new CheckCollection.Check(
+                $"TagManager Settings", "Auto applying Tags and Layers from Preset",
+                () => {
+                    var cachedActiveObject = Selection.activeObject;
+                    Preset tagManagerPreset = (Preset)AssetDatabase.LoadAssetAtPath("Packages/com.veryrealhelp.helpclubcommon/Presets/TagManager.preset", typeof(Preset));
+                    Selection.activeObject = Unsupported.GetSerializedAssetInterfaceSingleton("TagManager");
+                    bool presetEquals = tagManagerPreset.DataEquals(Selection.activeObject);
+                    Selection.activeObject = cachedActiveObject;
+                    return presetEquals;
+                },
+                () =>
+                {
+                    var cachedActiveObject = Selection.activeObject;
+                    Preset tagManagerPreset = (Preset)AssetDatabase.LoadAssetAtPath("Packages/com.veryrealhelp.helpclubcommon/Presets/TagManager.preset", typeof(Preset));
+                    Selection.activeObject = SettingsService.OpenProjectSettings("Project/TagManager");
+                    Selection.activeObject = Unsupported.GetSerializedAssetInterfaceSingleton("TagManager");
+                    tagManagerPreset.ApplyTo(Selection.activeObject);
                     Selection.activeObject = cachedActiveObject;
                 }
             )

--- a/Presets/TagManager.preset
+++ b/Presets/TagManager.preset
@@ -1,0 +1,166 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!181963792 &2655988077585873504
+Preset:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: TagManager
+  m_TargetType:
+    m_NativeTypeID: 78
+    m_ManagedTypePPtr: {fileID: 0}
+    m_ManagedTypeFallback: 
+  m_Properties:
+  - target: {fileID: 0}
+    propertyPath: tags.Array.size
+    value: 0
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.size
+    value: 32
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[0]
+    value: Default
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[1]
+    value: TransparentFX
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[2]
+    value: Ignore Raycast
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[3]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[4]
+    value: Water
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[5]
+    value: UI
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[6]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[7]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[8]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[9]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[10]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[11]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[12]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[13]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[14]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[15]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[16]
+    value: MirrorOnly
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[17]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[18]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[19]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[20]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[21]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[22]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[23]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[24]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[25]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[26]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[27]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[28]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[29]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[30]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: layers.Array.data[31]
+    value: 
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_SortingLayers.Array.size
+    value: 1
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_SortingLayers.Array.data[0].name
+    value: Default
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_SortingLayers.Array.data[0].uniqueID
+    value: 0
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: m_SortingLayers.Array.data[0].locked
+    value: 0
+    objectReference: {fileID: 0}

--- a/Presets/TagManager.preset.meta
+++ b/Presets/TagManager.preset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6281bc9341771a6448a0a496b20981c3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2655988077585873504
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Bundles.meta
+++ b/Runtime/Bundles.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 483230fd816fa404e8ea9f8dfedd90a4
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "com.veryrealhelp.helpclubcommon",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "displayName": "VRH Help Club Common",
   "description": "Shared resources for the various Help Club Unity projects.",
   "unity": "2018.4",
   "repository": {
     "type": "git",
     "url": "git@github.com:Very-Real-Help-LLC/com.veryrealhelp.helpclubcommon.git",
-    "revision": "0.8.7"
+    "revision": "0.8.8"
   },
   "dependencies": {
     "com.unity.editorcoroutines": "0.1.0-preview.1",


### PR DESCRIPTION
- Added TagManager.preset containing layer 16 MirrorOnly
- Added TagManager (and layer) check to WorldValidator
- Changed language for preset checks
- Fixed typo in preset comments
- Bumped package.json Version to 0.8.8
- Removed deprecated Bundles.meta to reduce error outputs during import and build