### PR TITLE
Removed VR checks from required player settings

### DIFF
--- a/Editor/WorldValidator.cs
+++ b/Editor/WorldValidator.cs
@@ -82,21 +82,6 @@ namespace VeryRealHelp.HelpClubCommon.Editor
                 () => EditorUserBuildSettings.androidBuildSubtarget = MobileTextureSubtarget.ASTC
             ),
             new CheckCollection.Check(
-                "Android VR", "Should be enabled",
-                () => PlayerSettings.GetVirtualRealitySupported(BuildTargetGroup.Android),
-                () => PlayerSettings.SetVirtualRealitySupported(BuildTargetGroup.Android, true)
-            ),
-            new CheckCollection.Check(
-                "Standalone VR", "Should be enabled",
-                () => PlayerSettings.GetVirtualRealitySupported(BuildTargetGroup.Standalone),
-                () => PlayerSettings.SetVirtualRealitySupported(BuildTargetGroup.Standalone, true)
-            ),
-            new CheckCollection.Check(
-                "Stereo Rendering Mode", "Should be set to Single Pass",
-                () => PlayerSettings.stereoRenderingPath == StereoRenderingPath.SinglePass,
-                () => PlayerSettings.stereoRenderingPath = StereoRenderingPath.SinglePass
-            ),
-            new CheckCollection.Check(
                 "Render Pipeline", "Should use Unity Standard Rendering",
                 () => GraphicsSettings.renderPipelineAsset == null
             ),


### PR DESCRIPTION
With the upgrade to Unity 2020 most of the checks around VR related player settings have been deprecated.

There is no technical dependency for XR settings in our world and prop repositories and those settings are not relevant for building asset bundles. No need to implement checks for the new XR Management either.