### PR TITLE
Automatically assign asset bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ sysinfo.txt
 # Crashlytics generated file
 crashlytics-build.properties
 
+Editor/.idea

--- a/Editor/BuildSizeViewer.cs
+++ b/Editor/BuildSizeViewer.cs
@@ -1,0 +1,245 @@
+﻿// This script was originally created by MunifiSense to analyze VRC asset bundles.
+// View the original source here https://github.com/MunifiSense/VRChat-Build-Size-Viewer
+// The original script is MIT licensed, so it's safe for us to use and distribute.
+// I have heavily modified it to support multi-bundle loading, and tailored it around our specific asset bundle build automation
+// Unity provides more information about asset bundles in the hidden editor log when building, than it exposes via apis. 
+// This script scrapes those logs and presents the data in a relevant way.
+// I've also added in support for diffing scene and stuff bundles, in order to find memory duplication
+
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Editor
+{
+    public class BuildSizeViewer : EditorWindow {
+        
+        private readonly string _buildLogPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "/Unity/Editor/Editor.log";
+        private readonly char[] _delimiterChars = { ' ', '\t' };
+        private int _buildTargetIndex;
+        private readonly string[] _buildTargets = { "Android", "StandaloneOSX", "StandaloneWindows", "iOS" };
+        
+        private class BuildObject {
+            public string Size;
+            public string Percent;
+            public string Path;
+            public bool Duplicate;
+        }
+
+        private class BundleInfo
+        {
+            public bool BuildLogFound;
+            public string BundleName;
+            
+            public List<BuildObject> BuildObjectList;
+            public List<string> UncompressedList;
+            
+            public string TotalSize;
+            public Vector2 ScrollPos;    
+        }
+        private readonly BundleInfo _sceneBundleInfo = new BundleInfo();
+        private readonly BundleInfo _assetsBundleInfo = new BundleInfo();
+        
+        [MenuItem("VRH/Automation/Asset Bundle Build Size Viewer")]
+
+        public static void ShowWindow() {
+            GetWindow(typeof(BuildSizeViewer));
+        }
+
+        private void OnGUI()
+        {
+            // Define the bundle names using Application.productName as a prefix
+            string assetBundlePrefix = Application.productName.ToLower().Replace(" ", "_");
+            
+            _sceneBundleInfo.BundleName = $"{assetBundlePrefix}_scene";
+            _assetsBundleInfo.BundleName = $"{assetBundlePrefix}_stuff";
+            
+            EditorGUILayout.LabelField("Asset Bundle Build Size Viewer", EditorStyles.boldLabel);
+            EditorGUILayout.LabelField("Run the build automation to generate bundles, then click the button!", EditorStyles.label);
+            _buildTargetIndex = EditorGUILayout.Popup("Build Target", _buildTargetIndex, _buildTargets);
+            if (GUILayout.Button("Read Build Log")) {
+                _sceneBundleInfo.BuildLogFound = GetBuildSize(_sceneBundleInfo);
+                _assetsBundleInfo.BuildLogFound = GetBuildSize(_assetsBundleInfo);
+                if (_sceneBundleInfo.BuildLogFound && _assetsBundleInfo.BuildLogFound)
+                {
+                    DiffBundles();
+                }
+            }
+            if (_sceneBundleInfo.BuildLogFound && _assetsBundleInfo.BuildLogFound)
+            {
+                EditorGUILayout.BeginHorizontal();
+                DrawBuildLog(_sceneBundleInfo);
+                DrawBuildLog(_assetsBundleInfo);
+                EditorGUILayout.EndHorizontal();
+            }
+            else
+            {
+                EditorGUILayout.LabelField("Couldn't find bundle build logs");
+            }
+        }
+
+        private void DiffBundles()
+        {
+            foreach (var buildObject1 in _sceneBundleInfo.BuildObjectList)
+            {
+                foreach (var buildObject2 in _assetsBundleInfo.BuildObjectList.Where(buildObject2 => buildObject1.Path == buildObject2.Path))
+                {
+                    buildObject1.Duplicate = true;
+                    buildObject2.Duplicate = true;
+                }
+            }
+        }
+
+        private void DrawBuildLog(BundleInfo bundleInfo)
+        {
+            EditorGUILayout.BeginVertical();
+            EditorGUILayout.LabelField(bundleInfo.BundleName);
+            if (bundleInfo.UncompressedList != null && bundleInfo.UncompressedList.Count != 0) {
+                EditorGUILayout.LabelField("Total Compressed Build Size: " + bundleInfo.TotalSize);
+                EditorGUILayout.BeginHorizontal();
+                EditorGUILayout.Separator();
+                EditorGUILayout.EndHorizontal();
+                foreach (var entry in bundleInfo.UncompressedList) {
+                    EditorGUILayout.LabelField(entry);
+                }
+            }
+
+            if (bundleInfo.BuildObjectList == null || bundleInfo.BuildObjectList.Count == 0)
+            {
+                EditorGUILayout.LabelField("No Build Objects Found");
+                return;
+            }
+        
+            var windowWidth = (float)(position.width * 0.6);
+            var percentLabelWidth = (float)(windowWidth * 0.15);
+            var sizeLabelWidth = (float)(windowWidth * 0.15);
+            var buttonLabelWidth = (float)(windowWidth * 0.15);
+            var pathLabelWidth = (float)(windowWidth * 0.35);
+
+            var warningStyle = new GUIStyle(EditorStyles.label)
+            {
+                normal =
+                {
+                    textColor = Color.yellow
+                }
+            };
+
+            bundleInfo.ScrollPos = EditorGUILayout.BeginScrollView(bundleInfo.ScrollPos);
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.Separator();
+            EditorGUILayout.EndHorizontal();
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.LabelField("Size%", GUILayout.Width(percentLabelWidth));
+            EditorGUILayout.LabelField("Size", GUILayout.Width(sizeLabelWidth));
+            EditorGUILayout.LabelField("Path", GUILayout.Width(pathLabelWidth));
+            EditorGUILayout.EndHorizontal();
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.Separator();
+            EditorGUILayout.EndHorizontal();
+            EditorGUILayout.LabelField("Used Assets and files from the Resources folder, sorted by uncompressed size:");
+            foreach (var buildObject in bundleInfo.BuildObjectList) {
+                EditorGUILayout.BeginHorizontal();
+                EditorGUILayout.LabelField(buildObject.Percent, GUILayout.Width(percentLabelWidth));
+                EditorGUILayout.LabelField(buildObject.Size, GUILayout.Width(sizeLabelWidth));
+                if(buildObject.Duplicate)
+                    EditorGUILayout.LabelField(buildObject.Path, warningStyle);
+                else
+                    EditorGUILayout.LabelField(buildObject.Path);
+                
+                if(buildObject.Path != "Resources/unity_builtin_extra") {
+                    if (GUILayout.Button("Go", GUILayout.Width(buttonLabelWidth))) {
+                        var obj = AssetDatabase.LoadAssetAtPath(buildObject.Path, typeof(Object));
+                        Selection.activeObject = obj;
+                        EditorGUIUtility.PingObject(obj);
+                    }
+                }
+                EditorGUILayout.EndHorizontal();
+            }
+            EditorGUILayout.EndScrollView();
+            EditorGUILayout.EndVertical();
+        }
+
+        private bool GetBuildSize(BundleInfo bundleInfo)
+        {
+            var buildLogCopyPath = $"{_buildLogPath}copy";
+            Debug.Log(buildLogCopyPath);
+        
+            // Make a copy of the editor log file
+            FileUtil.ReplaceFile(_buildLogPath, buildLogCopyPath);
+        
+            //Read the text from log
+            var reader = new StreamReader(buildLogCopyPath);
+        
+            var foundBuildTarget = TryReadUntilLineContains(ref reader, $"Building {_buildTargets[_buildTargetIndex]}...", out _);
+            var foundBundleName = TryReadUntilLineContains(ref reader, $"Bundle Name: {bundleInfo.BundleName}", out _);
+        
+            // Read the build info 
+            if (foundBuildTarget && foundBundleName)
+            {
+                bundleInfo.BuildObjectList = new List<BuildObject>();
+                bundleInfo.UncompressedList = new List<string>();
+
+                if (TryReadUntilLineContains(ref reader, "Compressed Size:", out var totalSizeLine))
+                {
+                    bundleInfo.TotalSize = totalSizeLine.Split(':')[1];
+                }
+                
+                // Read through the list of assets
+                ForeachLineUntilLineContains(ref reader,
+                    "Used Assets and files from the Resources folder, sorted by uncompressed size:", 
+                    line => { bundleInfo.UncompressedList.Add(line); }
+                );
+
+                // Read through the build objects
+                ForeachLineUntilLineContains(ref reader,
+                    "-------------------------------------------------------------------------------",
+                    line =>
+                    {
+                        var splitLine = line.Split(_delimiterChars);
+                        var temp = new BuildObject
+                        {
+                            Size = splitLine[1] + splitLine[2],
+                            Percent = splitLine[4],
+                            Path = splitLine[5]
+                        };
+                        for (var i = 6; i < splitLine.Length; i++)
+                        {
+                            temp.Path += $" {splitLine[i]}";
+                        }
+
+                        bundleInfo.BuildObjectList.Add(temp);
+                    });
+            }
+
+            // Cleanup
+            FileUtil.DeleteFileOrDirectory(buildLogCopyPath);
+            reader.Close();
+        
+            return foundBuildTarget && foundBundleName;
+        }
+    
+        private static bool TryReadUntilLineContains(ref StreamReader reader, string targetLine, out string line)
+        {
+            while ((line = reader.ReadLine()) != null)
+            {
+                if (line.Contains(targetLine)) return true;
+            }
+            return false;
+        }
+
+        private static void ForeachLineUntilLineContains(ref StreamReader reader, string targetLine, Action<string> action)
+        {
+            while (reader.ReadLine() is { } line)
+            {
+                if(line.Contains(targetLine)) return;
+                action.Invoke(line);
+            }
+        }
+    }
+}
+#endif

--- a/Editor/BuildSizeViewer.cs.meta
+++ b/Editor/BuildSizeViewer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 424e00d59365db84bb2c8dc0b3635674
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/HelpClubUtility.cs
+++ b/Editor/HelpClubUtility.cs
@@ -224,7 +224,8 @@ namespace VeryRealHelp.HelpClubCommon.Editor
             new CheckSet() { label = "Project Settings", checks = WorldValidator.settingsChecks, autoFix = true },
             new CheckSet() { label = "Scene Requirements", checks = WorldValidator.sceneRequirementChecks, autoFix = false },
             new CheckSet() { label = "Scene Suggestions", checks = sceneSuggestions, autoFix = false, severity = CheckSet.Severity.Suggestion },
-            new CheckSet() { label = "World Info Files", checks = WorldValidator.worldInfoChecks, autoFix = false},
+            new CheckSet() { label = "Asset Bundles", checks = WorldValidator.assetBundleChecks, autoFix = true, severity = CheckSet.Severity.Requirement},
+            new CheckSet() { label = "World Info Files", checks = WorldValidator.worldInfoChecks, autoFix = true, severity = CheckSet.Severity.Requirement},
             //new CheckSet() { label = "Assets", checks = assetChecks, autoFix = false, severity = CheckSet.Severity.Suggestion },
         };
 

--- a/Editor/WorldValidator.cs
+++ b/Editor/WorldValidator.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.SceneManagement;
 using VeryRealHelp.HelpClubCommon.World;
+using Object = UnityEngine.Object;
 
 namespace VeryRealHelp.HelpClubCommon.Editor
 {
@@ -278,8 +279,36 @@ namespace VeryRealHelp.HelpClubCommon.Editor
                         }
                     ),
                     new CheckCollection.Check(
+                        "Check Asset Bundle Assignments",
+                        "Ensure all scene assets are assigned to the correct asset bundles",
+                        test: () => {
+                            // Check if assets are already assigned to the correct bundles
+                            return AreAssetsAssignedToCorrectBundles();
+                        },
+                        fix: () => {
+                            // Assign assets to the correct bundles if needed
+                            AssignAssetsToBundles();
+                        }
+                    ),
+                    new CheckCollection.Check(
+                        $"WorldInfo: {worldInfo.name}", "WorldInfo should be in the info bundle",
+                        () =>
+                        {
+                            // Define the bundle names using Application.productName as a prefix
+                            var assetBundlePrefix = Application.productName.ToLower().Replace(" ", "_");
+                            var infoBundleName = $"{assetBundlePrefix}_info";
+                            return CheckAssetBundleName(worldInfo, infoBundleName);
+                        }, () =>
+                        {
+                            // Define the bundle names using Application.productName as a prefix
+                            var assetBundlePrefix = Application.productName.ToLower().Replace(" ", "_");
+                            var infoBundleName = $"{assetBundlePrefix}_info";
+                            TrySetAssetBundleName(worldInfo, infoBundleName);
+                        }
+                    ),
+                    new CheckCollection.Check(
                         $"WorldInfo: {worldInfo.name}", "Bundles should have a Render Settings File",
-                        () => {
+                        test: () => {
                             var sceneAssetName = AssetDatabase.GetAssetPath(worldInfo.sceneAsset);
                             var sceneBundleName = AssetDatabase.GetImplicitAssetBundleName(sceneAssetName);
                             var bundleNames = AssetDatabase.GetAssetBundleDependencies(sceneBundleName, true);
@@ -287,6 +316,33 @@ namespace VeryRealHelp.HelpClubCommon.Editor
                                 .Select(AssetDatabase.GUIDToAssetPath)
                                 .Select(AssetDatabase.GetImplicitAssetBundleName)
                                 .Any(renderSettingsBundleName => bundleNames.Contains(renderSettingsBundleName));
+                        },
+                        fix: () => {
+                            var sceneAssetName = AssetDatabase.GetAssetPath(worldInfo.sceneAsset);
+                            var sceneBundleName = AssetDatabase.GetImplicitAssetBundleName(sceneAssetName);
+                            var bundleNames = AssetDatabase.GetAssetBundleDependencies(sceneBundleName, true);
+
+                            // Assuming we use the first bundle name from the dependencies
+                            string targetBundleName = bundleNames.FirstOrDefault();
+                            if (string.IsNullOrEmpty(targetBundleName))
+                            {
+                                Debug.LogWarning("No bundle dependencies found. Cannot assign RenderSettingsFile to a bundle.");
+                                return;
+                            }
+
+                            string[] renderSettingsFiles = AssetDatabase.FindAssets("t:RenderSettingsFile");
+                            if (renderSettingsFiles.Length > 0)
+                            {
+                                string firstRenderSettingsFilePath = AssetDatabase.GUIDToAssetPath(renderSettingsFiles[0]);
+                                AssetImporter importer = AssetImporter.GetAtPath(firstRenderSettingsFilePath);
+                                importer.SetAssetBundleNameAndVariant(targetBundleName, "");
+
+                                Debug.Log($"RenderSettingsFile '{firstRenderSettingsFilePath}' assigned to bundle '{targetBundleName}'.");
+                            }
+                            else
+                            {
+                                Debug.LogWarning("No RenderSettingsFile found to assign to bundle.");
+                            }
                         }
                     ),
                     new CheckCollection.Check(
@@ -327,5 +383,228 @@ namespace VeryRealHelp.HelpClubCommon.Editor
         );
 
         #endregion
+        
+        [MenuItem("VRH/Automation/Delete All Asset Bundles")]
+        public static void DeleteAllAssetBundles()
+        {
+            // Get all asset bundle names currently in use
+            var allBundleNames = AssetDatabase.GetAllAssetBundleNames();
+
+            foreach (var bundleName in allBundleNames)
+            {
+                // Remove the asset bundle and its dependencies
+                var result = AssetDatabase.RemoveAssetBundleName(bundleName, true);
+
+                if (result)
+                {
+                    Debug.Log($"Removed asset bundle: {bundleName}");
+                }
+                else
+                {
+                    Debug.LogWarning($"Failed to remove asset bundle: {bundleName}");
+                }
+            }
+
+            // Save and refresh the AssetDatabase to reflect the changes
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+
+            Debug.Log($"Deleted all asset bundles. Total: {allBundleNames.Length}");
+        }
+        
+        [MenuItem("VRH/Automation/Assign Assets To Bundles")]        
+        public static void AssignAssetsToBundles()
+        {
+            // Define the bundle names using Application.productName as a prefix
+            var assetBundlePrefix = Application.productName.ToLower().Replace(" ", "_");
+            
+            var sceneBundleName = $"{assetBundlePrefix}_scene";
+            var assetsBundleName = $"{assetBundlePrefix}_stuff";
+
+            // Assign the current scene to a bundle
+            var scenePath = SceneManager.GetActiveScene().path;
+            AssetImporter.GetAtPath(scenePath).SetAssetBundleNameAndVariant(sceneBundleName, "");
+
+            // Iterate over all GameObjects in the scene
+            foreach (var obj in Object.FindObjectsOfType<GameObject>())
+            {
+                SetAssetBundleNameForAllProperties(obj, assetsBundleName);
+                Object prefabAsset = PrefabUtility.GetCorrespondingObjectFromSource(obj);
+                if (prefabAsset != null)
+                {
+                    SetAssetBundleNameForAllProperties(prefabAsset, assetsBundleName);    
+                }
+                
+                // Get all components on the GameObject, including children and inactive components
+                var components = obj.GetComponentsInChildren<Component>(true);
+                foreach (var component in components)
+                {
+                    SetAssetBundleNameForAllProperties(component, assetsBundleName);
+                }
+            }
+
+            var skyboxMaterial = RenderSettings.skybox;
+            if (skyboxMaterial != null)
+            {
+                SetAssetBundleNameForAllProperties(skyboxMaterial, assetsBundleName);
+            }
+
+            Debug.Log("Assets have been assigned to their respective bundles.");
+        }
+
+        private static bool AreAssetsAssignedToCorrectBundles()
+        {
+            // Define the bundle names using Application.productName as a prefix
+            var assetBundlePrefix = Application.productName.ToLower().Replace(" ", "_");
+            
+            var sceneBundleName = $"{assetBundlePrefix}_scene";
+            var assetsBundleName = $"{assetBundlePrefix}_stuff";
+
+            // Check the current scene's bundle assignment
+            var scenePath = SceneManager.GetActiveScene().path;
+            var sceneAssetBundleName = AssetImporter.GetAtPath(scenePath).assetBundleName;
+            if (sceneAssetBundleName != sceneBundleName)
+            {
+                return false; // Scene is not assigned to the correct bundle
+            }
+
+            // Iterate over all GameObjects in the scene
+            foreach (var obj in Object.FindObjectsOfType<GameObject>())
+            {
+                Object prefabAsset = PrefabUtility.GetCorrespondingObjectFromSource(obj);
+                if (prefabAsset != null)
+                {
+                    CheckAssetBundleNameForAllProperties(prefabAsset, assetsBundleName);    
+                }
+                
+                CheckAssetBundleNameForAllProperties(obj, assetsBundleName);
+                
+                // Get all components on the GameObject, including children and inactive components
+                var components = obj.GetComponentsInChildren<Component>(true);
+                foreach (var component in components)
+                {
+                    var valid = CheckAssetBundleNameForAllProperties(component, assetsBundleName);
+                    if (!valid) return false;
+                }
+            }
+
+            var skyboxMaterial = RenderSettings.skybox;
+            if (skyboxMaterial != null)
+            {
+                var valid = CheckAssetBundleNameForAllProperties(skyboxMaterial, assetsBundleName);
+                if (!valid) return false;
+            }
+
+            // All assets are correctly assigned
+            return true;
+        }
+
+        private static void SetAssetBundleNameForAllProperties(Object unityObject, string assetsBundleName)
+        {
+            // Set the asset bundle name for the root object
+            TrySetAssetBundleName(unityObject, assetsBundleName);
+
+            // Start the recursive process for the initial object
+            SetAssetBundleNameRecursively(unityObject);
+            return;
+
+            // Recursive function to set asset bundle names for all dependencies
+            void SetAssetBundleNameRecursively(Object obj)
+            {
+                var so = new SerializedObject(obj);
+                var sp = so.GetIterator();
+
+                while (sp.NextVisible(true))
+                {
+                    if (sp.propertyType == SerializedPropertyType.ObjectReference && sp.objectReferenceValue != null)
+                    {
+                        // Set the asset bundle name for the dependency
+                        TrySetAssetBundleName(sp.objectReferenceValue, assetsBundleName);
+
+                        // Recursively set asset bundle names for the dependencies of the current object
+                        if (sp.objectReferenceValue != unityObject) // Prevent infinite recursion
+                        {
+                            SetAssetBundleNameRecursively(sp.objectReferenceValue);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static bool CheckAssetBundleNameForAllProperties(Object unityObject, string assetsBundleName)
+        {
+            // Start the recursive checking process
+            return CheckRecursively(unityObject);
+
+            // Local function for recursive checking
+            bool CheckRecursively(Object obj)
+            {
+                var so = new SerializedObject(obj);
+                var sp = so.GetIterator();
+
+                if (!CheckAssetBundleName(obj, assetsBundleName))
+                {
+                    // Asset is not assigned to the correct bundle
+                    return false;
+                }
+
+                while (sp.NextVisible(true))
+                {
+                    if (sp.propertyType == SerializedPropertyType.ObjectReference && sp.objectReferenceValue != null)
+                    {
+                        if (!CheckAssetBundleName(sp.objectReferenceValue, assetsBundleName))
+                        {
+                            // Asset is not assigned to the correct bundle
+                            return false;
+                        }
+
+                        // Recurse into the current property's referenced object, avoiding infinite recursion
+                        if (sp.objectReferenceValue != obj && !CheckRecursively(sp.objectReferenceValue))
+                        {
+                            return false;
+                        }
+                    }
+                }
+                return true;
+            }
+        }
+
+
+        private static bool CanAssetBeImported(string assetPath)
+        {
+            // Don't try to touch default unity assets
+            if(assetPath == "Library/unity default resources" || assetPath == "Resources/unity_builtin_extra") return false;
+
+            // Exclude script assets and package assets
+            if (string.IsNullOrEmpty(assetPath) || assetPath.EndsWith(".cs") ||
+                assetPath.StartsWith("Packages/")) return false;
+            
+            return true;
+        }
+
+        private static bool TrySetAssetBundleName(Object unityObject, string assetBundleName)
+        {
+            var baseAssetPath = AssetDatabase.GetAssetPath(unityObject);
+            if(!CanAssetBeImported(baseAssetPath)) return false;
+            var baseImportedAsset = AssetImporter.GetAtPath(baseAssetPath);
+            if (baseImportedAsset == null) return false;
+            baseImportedAsset.SetAssetBundleNameAndVariant(assetBundleName, "");
+            return true;
+        }
+
+        private static bool CheckAssetBundleName(Object unityObject, string assetBundleName)
+        {
+            var baseAssetPath = AssetDatabase.GetAssetPath(unityObject);
+            
+            // We only need to check importable assets
+            if(!CanAssetBeImported(baseAssetPath)) return true;
+            
+            var baseImportedAsset = AssetImporter.GetAtPath(baseAssetPath);
+            if (baseImportedAsset != null) return baseImportedAsset.assetBundleName == assetBundleName;
+            
+            Debug.LogWarning($"Failed to import asset at path {baseAssetPath}");
+            return false;
+        }
+
     }
 }


### PR DESCRIPTION
Adds a new `checkcollections` to automatically detect and set correct asset bundle names for all assets in the scene, and related assets. 
This fixes issues with assets being duplicated in memory due to being referenced in multiple bundles at once.
it also fixes issues with old unused assets being left in bundles because they were never unassigned a bundle name.

Included in the PR is a tool I extended to view extra information about asset bundles that's scraped from the editor logs.

Testing Information:
This automatically runs when you build asset bundles for a world using this version of the SDK.
You can test this using the branch of the commons I have another PR open for here: [Optimized Bundles](https://github.com/Very-Real-Help-LLC/Commons/pull/1)

This will run with the bundle build automation, but if you want to see what it's doing locally, you can open the commons project and play with the following new menu items:
- VRH/Automation/Run Build Automation
    - Builds all bundles just like the cloud runner does
- VRH/Automation/Delete All Bundles
    - Removes all bundle assignments and deletes the bundles. This is just for testing.
- VRH/Automation/Assign Assets To Bundles
    - Runs the new bundle assignment code, without actually building bundles. This is just for testing.
- VRH/Automation/Asset Bundle Build Size Viewer
    - You have to run this *after* running build automation.
    - This lets you preview the asset bundle build editor logs, which provides extra insight into the build process. The information it shows has some overlap with what's visible in Window/AssetBundle Browser (Unity's bundle viewing tool), but it also shows some stuff that the browser doesn't, so both are useful for testing.